### PR TITLE
Add archived uploads counter and corresponding logic in audio recorder

### DIFF
--- a/SpeakStoreLocate.Client/src/app/audio-recorder/audio-recorder.component.html
+++ b/SpeakStoreLocate.Client/src/app/audio-recorder/audio-recorder.component.html
@@ -175,4 +175,9 @@
       </mat-card-content>
     </mat-card>
   </div>
+
+  <!-- Archived uploads counter (page end) -->
+  <div style="margin-top: 10px; opacity: 0.8; font-size: 12px; text-align: center;">
+    Archivierte Uploads: {{ archivedUploadsCount }}
+  </div>
 </div>

--- a/SpeakStoreLocate.Client/src/app/audio-recorder/audio-recorder.component.ts
+++ b/SpeakStoreLocate.Client/src/app/audio-recorder/audio-recorder.component.ts
@@ -60,6 +60,11 @@ export class AudioRecorderComponent implements OnInit {
     return this.pendingUploads.filter(u => !u.archived);
   }
 
+  /** Archived uploads count (kept locally after successful upload). */
+  get archivedUploadsCount(): number {
+    return this.pendingUploads.filter(u => !!u.archived).length;
+  }
+
   // Editing state
   editingId?: string;
   editName: string = '';


### PR DESCRIPTION
This pull request adds a new feature to the `AudioRecorderComponent` that displays the number of archived uploads at the bottom of the page. The count is calculated and shown in the UI to improve user awareness of archived items.

**User interface enhancements:**

* Added a UI element at the bottom of `audio-recorder.component.html` to display the count of archived uploads.

**Component logic improvements:**

* Introduced a new `archivedUploadsCount` getter in `audio-recorder.component.ts` to calculate the number of archived uploads for display.